### PR TITLE
Fix 3d Model Not Changing When Changing Weapons

### DIFF
--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1018,7 +1018,7 @@ namespace DFUVR
     public class CorrectWeaponPatch : MonoBehaviour
     {
         [HarmonyPrefix]
-        static void Prefix(WeaponManager __instance)
+        internal static void Prefix(WeaponManager __instance)
         {
             if (Var.weaponObject != null)
                 Destroy(Var.weaponObject);
@@ -1071,6 +1071,18 @@ namespace DFUVR
                 Hands.rHand.SetActive(true);
                 Hands.lHand.SetActive(true);
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponManager), "ApplyWeapon")]
+    public class ApplyWeaponPatch : MonoBehaviour
+    {
+        [HarmonyPostfix]
+        static void Postfix(WeaponManager __instance)
+        {
+            if (__instance.ScreenWeapon == null || __instance.ScreenWeapon.SpecificWeapon == null ||
+                __instance.ScreenWeapon.SpecificWeapon.LongName != Var.currentWeaponName)
+                CorrectWeaponPatch.Prefix(__instance);
         }
     }
 

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1049,7 +1049,6 @@ namespace DFUVR
             Var.weaponObject = Instantiate(tempObject);
             Var.weaponObject.GetComponent<Collider>().enabled = true;
 
-            // if it is unsheathing
             if (__instance.Sheathed)
             {
                 Var.weaponObject.GetComponent<Collider>().enabled = false;

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1077,18 +1077,6 @@ namespace DFUVR
                 Hands.rHand.SetActive(false);
                 Hands.lHand.SetActive(false);
             }
-            else
-            {
-                Var.weaponObject.GetComponent<Collider>().enabled = false;
-                Var.weaponObject.transform.SetParent(Var.sheathObject.transform);
-
-                Var.weaponObject.transform.localPosition = currentHandObject.sheatedPositionOffset;
-                Var.weaponObject.transform.localRotation = currentHandObject.sheatedRotationOffset;
-                Var.sheathObject.GetComponent<MeshRenderer>().enabled = currentHandObject.renderSheated;
-
-                Hands.rHand.SetActive(true);
-                Hands.lHand.SetActive(true);
-            }
         }
     }
 

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1086,7 +1086,9 @@ namespace DFUVR
         [HarmonyPostfix]
         static void Postfix(WeaponManager __instance)
         {
-            CorrectWeaponPatch.Postfix(__instance);
+            DaggerfallUnityItem rightHandItem = GameManager.Instance.PlayerEntity.ItemEquipTable.GetItem(EquipSlots.RightHand);
+            if (rightHandItem == null || rightHandItem.LongName != Var.currentWeaponName)
+                CorrectWeaponPatch.Postfix(__instance);
         }
     }
 


### PR DESCRIPTION
This PR fixes 3d models not changing when changing weapons on the equipment screen.

It also now uses the correct sheath state to say it's unsheathed or not (the "ching" sound played when sheathing and not when unsheathing).