### PR TITLE
Weapons on Both Hands

### DIFF
--- a/DFUVR/HandObjectLoadList.cs
+++ b/DFUVR/HandObjectLoadList.cs
@@ -446,7 +446,6 @@ namespace DFUVR
             new HandObjectLoadList("AssetBundles/weapons", null, typeof(WeaponCollision), typeof(MeshCollider), new[] { WeaponTypes.LongBlade, WeaponTypes.LongBlade_Magic }, "Sword", Vector3.zero, Quaternion.identity, Vector3.zero, Quaternion.identity, true, true, true),
             new HandObjectLoadList("AssetBundles/weapons", null, typeof(WeaponCollision), typeof(MeshCollider), new[] { WeaponTypes.Dagger, WeaponTypes.Dagger_Magic }, "Steel_Dagger_512", Vector3.zero, Quaternion.Euler(0, 90, 90), Vector3.zero, Quaternion.Euler(0, 90, 90), true),
             new HandObjectLoadList("AssetBundles/weapons", null, typeof(WeaponCollision), typeof(MeshCollider), new[] { WeaponTypes.Battleaxe, WeaponTypes.Battleaxe_Magic }, "MM_Axe_01_01_lod2", Vector3.zero, Quaternion.Euler(0, -90, 90), Vector3.zero, Quaternion.Euler(0, 180, 180)),
-            new HandObjectLoadList("AssetBundles/weapons", null, null, null, new[] { WeaponTypes.None }, "Sheath", Vector3.zero, Quaternion.identity, Vector3.zero, Quaternion.identity, true),
             new HandObjectLoadList("AssetBundles/weapons", null, typeof(WeaponCollision), typeof(MeshCollider), new[] { WeaponTypes.Mace, WeaponTypes.Mace_Magic }, "mace", new Vector3(0, 0, 0.1f), Quaternion.Euler(90, 0, 0), new Vector3(0, 0, 0.1f), Quaternion.Euler(90, 0, 0)),
             new HandObjectLoadList("AssetBundles/weapons", null, typeof(WeaponCollision), typeof(MeshCollider), new[] { WeaponTypes.Flail, WeaponTypes.Flail_Magic }, "mace", new Vector3(0, 0, 0.1f), Quaternion.Euler(90, 0, 0), new Vector3(0, 0, 0.1f), Quaternion.Euler(90, 0, 0)),
             new HandObjectLoadList("AssetBundles/weapons", null, typeof(WeaponCollision), typeof(BoxCollider), new[] { WeaponTypes.Warhammer, WeaponTypes.Warhammer_Magic }, "Warhammer_1", Vector3.zero, Quaternion.Euler(0, 0, 90), Vector3.zero, Quaternion.identity),
@@ -575,9 +574,10 @@ namespace DFUVR
                     }
                 }
                 // this is for accessing by name later
-                else if (!string.IsNullOrEmpty(handObjectLoad.assetName))
+                if (!string.IsNullOrEmpty(handObjectLoad.assetName))
                 {
-                    handObjectDictionaryByName.Add(handObjectLoad.assetName, new HandObject(handObjectLoad, gameObject));
+                    if (!handObjectDictionaryByName.ContainsKey(handObjectLoad.assetName))
+                        handObjectDictionaryByName.Add(handObjectLoad.assetName, new HandObject(handObjectLoad, gameObject));
                 }
 
                 handObjectLoad.postAction?.Invoke(gameObject);

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1018,7 +1018,7 @@ namespace DFUVR
     public class CorrectWeaponPatch : MonoBehaviour
     {
         [HarmonyPrefix]
-        static void Prefix(WeaponManager __instance)
+        internal static void Prefix(WeaponManager __instance)
         {
             if (Var.weaponObject != null)
                 Destroy(Var.weaponObject);
@@ -1071,6 +1071,18 @@ namespace DFUVR
                 Hands.rHand.SetActive(true);
                 Hands.lHand.SetActive(true);
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponManager), "ApplyWeapon")]
+    public class ApplyWeaponPatch : MonoBehaviour
+    {
+        [HarmonyPostfix]
+        static void Postfix(WeaponManager __instance)
+        {
+            if (__instance.ScreenWeapon == null || __instance.ScreenWeapon.SpecificWeapon == null ||
+                __instance.ScreenWeapon.SpecificWeapon.LongName != Var.currentWeaponName)
+                CorrectWeaponPatch.Prefix(__instance);
         }
     }
 

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1049,7 +1049,6 @@ namespace DFUVR
             Var.weaponObject = Instantiate(tempObject);
             Var.weaponObject.GetComponent<Collider>().enabled = true;
 
-            // if it is unsheathing
             if (__instance.Sheathed)
             {
                 Var.weaponObject.GetComponent<Collider>().enabled = false;

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -150,10 +150,14 @@ namespace DFUVR
     {
         static void Prefix(PlayerDeath __instance)
         {
-            if (Var.weaponObject != null)
-                Destroy(Var.weaponObject);
+            if (Var.leftWeaponObject != null)
+                Destroy(Var.leftWeaponObject);
+            if (Var.rightWeaponObject != null)
+                Destroy(Var.rightWeaponObject);
 
-            Var.currentWeaponName = null;
+            Var.currentLeftWeaponName = null;
+            Var.currentRightWeaponName = null;
+
             Hands.rHand.SetActive(true);
             Hands.lHand.SetActive(true);
         }

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1077,18 +1077,6 @@ namespace DFUVR
                 Hands.rHand.SetActive(false);
                 Hands.lHand.SetActive(false);
             }
-            else
-            {
-                Var.weaponObject.GetComponent<Collider>().enabled = false;
-                Var.weaponObject.transform.SetParent(Var.sheathObject.transform);
-
-                Var.weaponObject.transform.localPosition = currentHandObject.sheatedPositionOffset;
-                Var.weaponObject.transform.localRotation = currentHandObject.sheatedRotationOffset;
-                Var.sheathObject.GetComponent<MeshRenderer>().enabled = currentHandObject.renderSheated;
-
-                Hands.rHand.SetActive(true);
-                Hands.lHand.SetActive(true);
-            }
         }
     }
 

--- a/DFUVR/Plugin.cs
+++ b/DFUVR/Plugin.cs
@@ -1086,7 +1086,9 @@ namespace DFUVR
         [HarmonyPostfix]
         static void Postfix(WeaponManager __instance)
         {
-            CorrectWeaponPatch.Postfix(__instance);
+            DaggerfallUnityItem rightHandItem = GameManager.Instance.PlayerEntity.ItemEquipTable.GetItem(EquipSlots.RightHand);
+            if (rightHandItem == null || rightHandItem.LongName != Var.currentWeaponName)
+                CorrectWeaponPatch.Postfix(__instance);
         }
     }
 

--- a/DFUVR/Sheath.cs
+++ b/DFUVR/Sheath.cs
@@ -62,7 +62,7 @@ namespace DFUVR
             //sheath.transform.localRotation = Quaternion.identity;
 
             assetBundle.Unload(false);
-            Var.sheathObject=sheath;
+            Var.rightSheathObject=sheath;
 
             //sphere.transform.localPosition = sphere.transform.parent.InverseTransformPoint(Var.sheathOffset);
             sphere.transform.localPosition = Var.sheathOffset;

--- a/DFUVR/Var.cs
+++ b/DFUVR/Var.cs
@@ -80,12 +80,31 @@ namespace DFUVR
         public static GameObject VRParent;
         public static GameObject debugSphere;
 
+        public static GameObject mainHand
+        {
+            get
+            {
+                return leftHanded ? leftHand : rightHand;
+            }
+        }
+        public static GameObject offHand
+        {
+            get
+            {
+                return leftHanded ? rightHand : leftHand;
+            }
+        }
+
         public static Dictionary<WeaponTypes, HandObject> handObjects = new Dictionary<WeaponTypes, HandObject>();
         public static Dictionary<string, HandObject> handObjectsByName = new Dictionary<string, HandObject>();
-        public static GameObject weaponObject;
-        public static string currentWeaponName;
 
-        public static GameObject sheathObject;
+        public static GameObject rightWeaponObject;
+        public static GameObject leftWeaponObject;
+        public static string currentRightWeaponName;
+        public static string currentLeftWeaponName;
+
+        public static GameObject rightSheathObject;
+        public static GameObject leftSheathObject;
 
         public static int connectedJoysticks;
 

--- a/DFUVR/WeaponCollision.cs
+++ b/DFUVR/WeaponCollision.cs
@@ -11,6 +11,7 @@ namespace DFUVR
 {
     public class WeaponCollision : MonoBehaviour
     {
+        public DaggerfallUnityItem item = null;
         //public float velocityThreshold = 2.0f;
 
         //private Rigidbody rb;
@@ -51,14 +52,13 @@ namespace DFUVR
                 Vector3 hitDirection = other.transform.position - transform.position;
                 Transform hitTransform = other.transform;
                 WeaponManager weaponManager = GameObject.Find("PlayerAdvanced").GetComponent<WeaponManager>();
-                DaggerfallUnityItem currentRightHandWeapon = (DaggerfallUnityItem)AccessTools.Field(typeof(WeaponManager), "currentRightHandWeapon").GetValue(weaponManager);
                 hitDirection = hitDirection.normalized;
                 //Debug.Log("Hit Direction: " + hitDirection);
 
                 var playerId = GameManager.Instance.PlayerObject.GetInstanceID();
                 if (playerId != other.gameObject.GetInstanceID())
                 {
-                    weaponManager.WeaponDamage(currentRightHandWeapon, false, false, hitTransform, hitTransform.localPosition, hitDirection);
+                    weaponManager.WeaponDamage(item, false, false, hitTransform, hitTransform.localPosition, hitDirection);
                     hitSomething = true;
                 }
             }

--- a/DFUVR/WeaponCollision.cs
+++ b/DFUVR/WeaponCollision.cs
@@ -6,6 +6,7 @@ using DFUVR;
 using HarmonyLib;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Questing;
+
 namespace DFUVR
 {
     public class WeaponCollision : MonoBehaviour
@@ -31,9 +32,8 @@ namespace DFUVR
 
         private void OnTriggerEnter(Collider other)
         {
-
-
             //Plugin.LoggerInstance.LogInfo("Hit something");
+            bool hitSomething = false;
 
             if (other.GetComponent<DaggerfallEntityBehaviour>())
             {
@@ -55,41 +55,41 @@ namespace DFUVR
                 hitDirection = hitDirection.normalized;
                 //Debug.Log("Hit Direction: " + hitDirection);
 
-                weaponManager.WeaponDamage(currentRightHandWeapon, false, false, hitTransform, hitTransform.localPosition, hitDirection);
-
+                var playerId = GameManager.Instance.PlayerObject.GetInstanceID();
+                if (playerId != other.gameObject.GetInstanceID())
+                {
+                    weaponManager.WeaponDamage(currentRightHandWeapon, false, false, hitTransform, hitTransform.localPosition, hitDirection);
+                    hitSomething = true;
+                }
             }
             else if (other.GetComponent<DaggerfallAction>())
             {
                 Plugin.LoggerInstance.LogInfo("Hit action");
-                DaggerfallAction action= other.GetComponent<DaggerfallAction>();
+                DaggerfallAction action = other.GetComponent<DaggerfallAction>();
                 if (Var.weaponManager != null)
                 {
                     GameObject player = (GameObject)AccessTools.Field(typeof(WeaponManager), "player").GetValue(Var.weaponManager);
                     action.Receive(player, DaggerfallAction.TriggerTypes.Attack);
+                    hitSomething = true;
                 }
                 else
                 {
                     Plugin.LoggerInstance.LogError("null");
                 }
-
             }
-            else if (other.GetComponent<DaggerfallActionDoor>()) 
+            else if (other.GetComponent<DaggerfallActionDoor>())
             {
                 //Plugin.LoggerInstance.LogInfo("Hit door");
                 DaggerfallActionDoor actionDoor = other.GetComponent<DaggerfallActionDoor>();
                 if (actionDoor)
                 {
                     actionDoor.AttemptBash(true);
+                    hitSomething = true;
                 }
-
-
             }
 
-            Haptics.TriggerHapticFeedback(UnityEngine.XR.XRNode.RightHand, 0.6f);
-            //else if()
-
+            if (hitSomething)
+                Haptics.TriggerHapticFeedback(UnityEngine.XR.XRNode.RightHand, 0.6f);
         }
-
-
     }
 }


### PR DESCRIPTION
### **This PR requires #15 and #17 to be merged first**

This PR introduces the possibility to equip weapons on both hands. If not weapon is equipped on one of the hands, the default "hand" will be equipped and can be used for melee.

2 handed weapons are not treated differently yet. My take on this is that we should give weapons "weight" and then using a weapon 2 handed should make it "lighter", so there is no need to change anything on this PR.